### PR TITLE
fix(security): RUSTSEC + clippy audit 2026-05-23

### DIFF
--- a/standalone-crates/kimi-fann-core/Cargo.toml
+++ b/standalone-crates/kimi-fann-core/Cargo.toml
@@ -29,7 +29,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
 
 # Memory management and performance
-lru = "0.12"
+lru = "0.16"
 dashmap = { version = "6.0", features = ["serde"] }
 tokio = { version = "1.0", features = ["rt", "sync", "time"], optional = true }
 


### PR DESCRIPTION
## Summary

- Bumps `lru` from `0.12` to `0.16` in `standalone-crates/kimi-fann-core/Cargo.toml` to resolve RUSTSEC-2026-0002 (unsound advisory)
- `cargo audit` now reports zero vulnerabilities and zero warnings for the `kimi-fann-core` crate

## Security Advisories Fixed

| Advisory | Crate | Severity | Description |
|---|---|---|---|
| RUSTSEC-2026-0002 | `lru 0.12.5` | Unsound | `IterMut` violates Stacked Borrows by invalidating internal pointer. Patched at `>=0.16.3`. |

## Audit Scope

- `standalone-crates/kimi-fann-core` — fixed `lru 0.12.5 -> 0.16.4`
- `src/rs` workspace — has pre-existing `web-sys` version conflict between `qudag-core` and `ruv-fann-wasm` (conflict predates this PR; separate issue)
- No RUSTSEC advisories found for `bytes` or `time` crates (not present in this repo's dependency tree)

## Test Plan

- [ ] `cargo audit` in `standalone-crates/kimi-fann-core` passes with no warnings
- [ ] `lru::LruCache::new(NonZeroUsize)` API is unchanged between 0.12 and 0.16 — no code changes needed
- [ ] No regressions: pre-existing wasm-bindgen compile errors unchanged

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)